### PR TITLE
Weston output configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ Sending build context to Docker daemon  81.92kB
 Opening URL: inspector://192.168.1.170:12321
 ```
 
+### Compositor settings
+
+The browser relies on the Weston compositor to work. While the defaults are
+fine for most uses, some tweaks are allowed regarding the output resolution.
+
+| Environment variable                       | Options   | Default | Description
+|--------------------------------------------|-----------|---------|---------------------------------------------------
+| **`WPE_WESTON_OUTPUT_USE_CURRENT_MODE`**   | `0`, `1`  | `0`     | Inherit the display mode from KMS console
+| **`WPE_WESTON_OUTPUT_MAX_WIDTH`**          | `integer` | `0`     | Maximum horizontal resolution the compositor may set
+| **`WPE_WESTON_OUTPUT_MAX_HEIGHT`**         | `integer` | `0`     | Maximum vertical resolution the compositor may set
+
+The maximum-resolution environment variables rely on the list of modes
+advertised by the DRM subsystem. That means if you set for example the
+maximum horizontal resolution to `1920` and the list contains `3840x2160`,
+`2560x1440`, `1920x1080` and `1280x800`, `1920x1080` will be picked.
+
 ### Sound settings
 
 balena-browser-wpe relies on balena-audio for the audio processing. Check the specific

--- a/balena.yml
+++ b/balena.yml
@@ -40,6 +40,8 @@ data:
     - WPE_COG_RELAUNCH_DELAY: 5
     - WPE_PULSE_SERVER: 'unix:/run/pulse/pulseaudio.socket'
     - WPE_WESTON_OUTPUT_USE_CURRENT_MODE: 0
+    - WPE_WESTON_OUTPUT_MAX_WIDTH: 0
+    - WPE_WESTON_OUTPUT_MAX_HEIGHT: 0
   applicationConfigVariables:
     - BALENA_HOST_CONFIG_gpu_mem: 396
     - BALENA_HOST_CONFIG_gpu_mem_256: 128

--- a/balena.yml
+++ b/balena.yml
@@ -39,6 +39,7 @@ data:
     - WPE_COG_RELAUNCH: ''
     - WPE_COG_RELAUNCH_DELAY: 5
     - WPE_PULSE_SERVER: 'unix:/run/pulse/pulseaudio.socket'
+    - WPE_WESTON_OUTPUT_USE_CURRENT_MODE: 0
   applicationConfigVariables:
     - BALENA_HOST_CONFIG_gpu_mem: 396
     - BALENA_HOST_CONFIG_gpu_mem_256: 128

--- a/weston/weston-init
+++ b/weston/weston-init
@@ -35,4 +35,13 @@ if [ -f /sys/class/backlight/rpi_backlight/brightness ]; then
 	echo $RPI_BACKLIGHT > /sys/class/backlight/rpi_backlight/brightness
 fi
 
-weston --idle-time ${WESTON_IDLE_TIME} --tty 2 -c /weston.ini
+WPE_WESTON_OUTPUT_USE_CURRENT_MODE=${WPE_WESTON_OUTPUT_USE_CURRENT_MODE:-0}
+
+# Allow usage of --current-mode, to let the host system decide the resolution
+if [ "$WPE_WESTON_OUTPUT_USE_CURRENT_MODE" -eq 1 ]; then
+	WESTON_CURRENT_MODE="--current-mode"
+else
+	WESTON_CURRENT_MODE=""
+fi
+
+weston ${WESTON_CURRENT_MODE} --idle-time ${WESTON_IDLE_TIME} --tty 2 -c /weston.ini

--- a/weston/weston-init
+++ b/weston/weston-init
@@ -28,6 +28,60 @@ startup-animation=fade
 
 IEOF
 
+WPE_WESTON_OUTPUT_MAX_WIDTH=${WPE_WESTON_OUTPUT_MAX_WIDTH:-0}
+WPE_WESTON_OUTPUT_MAX_HEIGHT=${WPE_WESTON_OUTPUT_MAX_HEIGHT:-0}
+
+is_in_range() {
+    test "$2" -eq 0 -o "$1" -le "$2"
+}
+
+# Limit resolution if necessary
+if [ "$WPE_WESTON_OUTPUT_MAX_WIDTH" -gt 0 -o "$WPE_WESTON_OUTPUT_MAX_HEIGHT" -gt 0 ]; then
+    for outp in /sys/class/drm/card*-*; do
+        # no outputs
+        if [ ! -d "$outp" ]; then
+            break
+        fi
+        # skip if not enabled
+        if [ "$(cat ${outp}/enabled)" = "disabled" ]; then
+            continue
+        fi
+        # get the output name
+        outn=${outp#*-}
+        # check the modes
+        moden=0
+        foundres=
+        for mode in $(cat "${outp}/modes"); do
+            wres=${mode%x*}
+            hres=${mode#*x}
+            moden=$(($moden + 1))
+            # skip interlaced modes and other junk
+            if ! [ "$wres" -eq "$wres" -a "$hres" -eq "$hres" ] 2> /dev/null; then
+                continue
+            fi
+            # check resolution constraints
+            if ! is_in_range "$wres" "$WPE_WESTON_OUTPUT_MAX_WIDTH"; then
+                continue
+            fi
+            if ! is_in_range "$hres" "$WPE_WESTON_OUTPUT_MAX_HEIGHT"; then
+                continue
+            fi
+            # found an acceptable res
+            foundres="$mode"
+            break
+        done
+        # found a res to use and it's non-preferred, override in weston
+        if [ -n "$foundres" -a "$moden" -gt 1 ]; then
+            cat << IEOF >> /weston.ini
+
+[output]
+name=${outn}
+mode=${foundres}
+IEOF
+        fi
+    done
+fi
+
 # Set the backlight brightness of a Raspberry touchscreen
 # The environment variable RPI_BACKLIGHT can be set to a value 0-255.
 export RPI_BACKLIGHT=${RPI_BACKLIGHT:-255}


### PR DESCRIPTION
The first commit allows device users to configure their display mode via hdmi_mode and have weston respect it. Otherwise, weston will always try to use the highest available mode by default, which e.g. for 4K screens is too slow to be practical.

The second commit adds a degree of configurability, to be used when you don't want the `--current-mode` (i.e. when it's too inflexible for you). This is primarily useful when you have a variety of raspberry pi devices in your fleet that are connected to displays of varying resolutions that may include 4K displays as well as 720p displays, and you want to use native resolution for all but the 4K displays, but for 4K displays you want to use 1080p, because of 4K on raspberry pi being too slow.